### PR TITLE
Update en el codigo Horizontal

### DIFF
--- a/ProyectoFinal/src/scenes/EscenaHorizontal.js
+++ b/ProyectoFinal/src/scenes/EscenaHorizontal.js
@@ -17,8 +17,11 @@ class EscenaHorizontal extends Phaser.Scene {
 
 
 init(data) {
-    this.puntaje = data.puntaje || 0; // Recibir el puntaje de EscenaMain
+    this.puntaje = data.puntaje || 0;  //Recibir el puntaje de EscenaMain
     this.bossGenerado = data.bossGenerado || false;
+    this.vidasJugador = 3;
+    this.meteoritoEnGeneracion = false;
+    this.tiempoBoss = 0;   
 }
 
     preload() {


### PR DESCRIPTION
__INFO__

-Se corrigio el error donde el jugador al morir/ganar contaba con las vidas de la partida anterior y cuando perdia sus valores pasaban a negativos. (Solucionado)

-Se corrigio que tanto la generacion del meteorito sea acorde a la escena